### PR TITLE
Enabling Auth, Updating Mongo Java Driver to 3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ TODO: Example mongodb deployment provisioned using a Vagrantfile
 `docker pull mongo`
 
 Start the Docker container:
-`docker run -p 27017:27017 -d mongo`
+`docker run --name mongodb -p 27017:27017 -d mongo --auth --authenticationDatabase admin -u mongo -p mongo`
+
+Add the Initial Admin User:
+```
+$ docker exec -it mongodb mongo admin
+> db.createUser({ user: 'admin', pwd: 'password', roles: [{"role" : "readWriteAnyDatabase","db" : "admin"},{"role" : "userAdminAnyDatabase","db" : "admin"}] });
+```
 
 
 ## Deploy MongoDB using Vagrant

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ MongoDB Cloud Foundry Service Broker Example
 
 Suggested setup for local development:
 
-* [MongoDB instance](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/
+* [MongoDB instance](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/)
 * [PCFDev](https://network.pivotal.io/products/pcfdev)
 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-MongoDB Cloud Foundry Service Broker Example
-=======================
+Sample Spring Boot project using the [Spring Cloud - Cloud Foundry Service Broker](https://github.com/spring-cloud/spring-cloud-cloudfoundry-service-broker).
 
-Suggested setup for local development:
+# Overview
 
-* [MongoDB instance](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/)
-* [PCFDev](https://network.pivotal.io/products/pcfdev)
+This sample project uses the Spring Cloud - Cloud Foundry Service Broker to implement a MongoDB service. The MongoDB service also uses [spring-boot-data-mongodb](https://github.com/spring-projects/spring-boot/tree/master/spring-boot-starters/spring-boot-starter-data-mongodb) to persist service instances and bindings.
+
+## Getting Started
+
+You need to install and run MongoDB somewhere and configure connectivity in [application.yml](src/main/resources/application.yml).
+
+Build it:
+
+    ./gradlew build
+
+After building, you can push the broker app to Cloud Foundry or deploy it some other way and then [register it to Cloud Foundry](http://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker).
 
 
 ## Enable Auth in your MongoDB instance
@@ -25,18 +33,10 @@ Test that authentication is working as expected:
 
 Refer to the MongoDB docs for more details: https://docs.mongodb.com/manual/tutorial/enable-authentication/
 
-## Build the MongoDB Example Service Broker
-
-```
-git clone https://github.com/dave-malone/cloudfoundry-service-broker
-cd cloudfoundry-service-broker
-./gradlew assemble
-```
 
 ## Deploy the Service Broker to Cloud Foundry
 
 The service broker is configured via environment variables, which are defined in the manifest.yml file. Make the necessary changes to the MongoDB config in order to connect to your Mongo instance.
-
 
 Push the service broker as an app to Cloud Foundry:
 `cf push`

--- a/README.md
+++ b/README.md
@@ -1,18 +1,56 @@
-Sample Spring Boot project using the [Spring Cloud - Cloud Foundry Service Broker](https://github.com/spring-cloud/spring-cloud-cloudfoundry-service-broker).
+MongoDB Cloud Foundry Service Broker Example
+=======================
 
-# Overview
+Suggested setup for local development:
 
-This sample project uses the Spring Cloud - Cloud Foundry Service Broker to implement a MongoDB service. The MongoDB service also uses [spring-boot-data-mongodb](https://github.com/spring-projects/spring-boot/tree/master/spring-boot-starters/spring-boot-starter-data-mongodb) to persist service instances and bindings.
+* [Docker](https://www.docker.com/products/docker)
+* [PCFDev](https://network.pivotal.io/products/pcfdev)
 
-## Getting Started
+For a more permanent deployment, consider deploying mongodb on traditional VMs.
 
-You need to install and run MongoDB somewhere and configure connectivity in [application.yml](src/main/resources/application.yml).
+TODO: Example mongodb deployment provisioned using a Vagrantfile
 
-Build it:
+## Deploy MongoDB in a Docker Container
+`docker pull mongo`
 
-    ./gradlew build
-
-After building, you can push the broker app to Cloud Foundry or deploy it some other way and then [register it to Cloud Foundry](http://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker).
-
+Start the Docker container:
+`docker run -p 27017:27017 -d mongo`
 
 
+## Deploy MongoDB using Vagrant
+
+TODO - fork this repo: https://github.com/bobthecow/vagrant-mongobox
+determine whether the above repo is a good enough starting point, or whether
+it's simply better to use Puppet to provision the Vagrant machine with Mongo
+
+## Build the MongoDB Example Service Broker
+`git clone https://github.com/dave-malone/cloudfoundry-service-broker`
+`cd cloudfoundry-service-broker`
+
+The example service broker has been configured for use with PCFDev. This assumes that your MongoDB instance is routable at `host.pcfdev.io:27017`. Make the necessary changes in `src/main/resources/application.yml` to configure your service broker to use MongoDB deployed elsewhere.
+
+`./gradlew assemble`
+
+The ready to deploy application jar file will now be available under the build/libs directory.
+
+## Deploy the Service Broker to Cloud Foundry
+
+Push the service broker as an app to Cloud Foundry:
+`cf push mongodb-service-broker -p build/libs/cloudfoundry-mongodb-service-broker.jar`
+
+Get the default password from the application's logs:
+`cf logs mongodb-service-broker --recent | grep default`
+
+Register the service broker using the default username and the password obtained from the previous step:
+`cf csb mongodb user password http://mongodb-service-broker.local.pcfdev.io`
+
+Enable access to the service broker:
+`cf enable-service-access "Mongo DB"`
+
+Create a service instance:
+`cf cs "Mongo DB"  "Default Mongo Plan" mymongodb`
+
+
+## Deploy sample app which uses a MongoDB service instance
+
+TODO

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Enable access to the service broker:
 `cf enable-service-access mongodb`
 
 Create a service instance:
-`cf cs mongodb  "Default Mongo Plan" mymongodb`
+`cf cs mongodb default mymongodb`
 
 
 ## Deploy sample app which uses a MongoDB service instance

--- a/README.md
+++ b/README.md
@@ -49,8 +49,3 @@ Enable access to the service broker:
 
 Create a service instance:
 `cf cs mongodb default mymongodb`
-
-
-## Deploy sample app which uses a MongoDB service instance
-
-TODO

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ it's simply better to use Puppet to provision the Vagrant machine with Mongo
 
 ## Build the MongoDB Example Service Broker
 `git clone https://github.com/dave-malone/cloudfoundry-service-broker`
+
 `cd cloudfoundry-service-broker`
 
 The example service broker has been configured for use with PCFDev. This assumes that your MongoDB instance is routable at `host.pcfdev.io:27017`. Make the necessary changes in `src/main/resources/application.yml` to configure your service broker to use MongoDB deployed elsewhere.

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ repositories {
 
 dependencies {
     compile("org.springframework.cloud:spring-cloud-cloudfoundry-service-broker:${springCloudFoundryServiceBrokerVersion}")
+	// https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
+	compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
+	
     compile("org.springframework.boot:spring-boot-starter-data-mongodb:1.4.0.RELEASE")
     testCompile(group: "org.springframework.cloud", name: "spring-cloud-cloudfoundry-service-broker", version: "${springCloudFoundryServiceBrokerVersion}", classifier: "tests")
     testCompile("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'idea'
 apply plugin: 'spring-boot'
 
 ext {
-    springCloudFoundryServiceBrokerVersion = "1.0.0.RC3"
+    springCloudFoundryServiceBrokerVersion = "1.0.0.RELEASE"
     version =  '0.1.0.BUILD-SNAPSHOT'
 }
 
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     compile("org.springframework.cloud:spring-cloud-cloudfoundry-service-broker:${springCloudFoundryServiceBrokerVersion}")
-    compile("org.springframework.boot:spring-boot-starter-data-mongodb")
+    compile("org.springframework.boot:spring-boot-starter-data-mongodb:1.4.0.RELEASE")
     testCompile(group: "org.springframework.cloud", name: "spring-cloud-cloudfoundry-service-broker", version: "${springCloudFoundryServiceBrokerVersion}", classifier: "tests")
     testCompile("org.springframework.boot:spring-boot-starter-test")
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,13 @@
 ---
 applications:
-- name: mongo-broker
+- name: mongodb-service-broker
   memory: 1G
   instances: 1
   path: build/libs/cloudfoundry-mongodb-service-broker.jar
+  env:
+    MONGODB_HOST: host.pcfdev.io
+    MONGODB_PORT: 27017
+    MONGODB_USERNAME: admin
+    MONGODB_PASSWORD: password
+    SECURITY_USER_NAME: admin
+    SECURITY_USER_PASSWORD: admin

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/config/CatalogConfig.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/config/CatalogConfig.java
@@ -20,7 +20,7 @@ public class CatalogConfig {
 		return new Catalog(Collections.singletonList(
 				new ServiceDefinition(
 						"mongodb-service-broker",
-						"Mongo DB",
+						"mongodb",
 						"A simple MongoDB service broker implementation",
 						true,
 						false,

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/config/CatalogConfig.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/config/CatalogConfig.java
@@ -26,7 +26,7 @@ public class CatalogConfig {
 						false,
 						Collections.singletonList(
 								new Plan("mongo-plan",
-										"Default Mongo Plan",
+										"default",
 										"This is a default mongo plan.  All services are created equally.",
 										getPlanMetadata())),
 						Arrays.asList("mongodb", "document"),

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/config/MongoConfig.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/config/MongoConfig.java
@@ -1,15 +1,16 @@
 package org.springframework.cloud.servicebroker.mongodb.config;
 
 import java.net.UnknownHostException;
+import java.util.Arrays;
 
-import com.mongodb.ServerAddress;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 import com.mongodb.MongoClient;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
 
 @Configuration
 @EnableMongoRepositories(basePackages = "org.springframework.cloud.servicebroker.mongodb.repository")
@@ -21,9 +22,20 @@ public class MongoConfig {
 	@Value("${mongodb.port:27017}")
 	private int port;
 
+	@Value("${mongodb.username:admin}")
+	private String username;
+
+	@Value("${mongodb.password:password}")
+	private String password;
+
+	@Value("${mongodb.authdb:admin}")
+	private String authSource;
+
 	@Bean
 	public MongoClient mongoClient() throws UnknownHostException {
-		return new MongoClient(new ServerAddress(host, port));
+		final MongoCredential credential = MongoCredential.createScramSha1Credential(username, authSource, password.toCharArray());
+		return new MongoClient(new ServerAddress(host, port), Arrays.asList(credential));
 	}
-	
+
+
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoAdminService.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoAdminService.java
@@ -27,11 +27,12 @@ import com.mongodb.client.MongoDatabase;
 @Service
 public class MongoAdminService {
 
-	public static final String ADMIN_DB = "admin";
-
 	private Logger logger = LoggerFactory.getLogger(MongoAdminService.class);
 
 	private MongoClient client;
+	
+	@Value("${mongodb.authdb:admin}")
+	private String adminDatabase;
 	
 	@Value("${mongodb.username:admin}")
 	private String adminUsername;
@@ -57,7 +58,7 @@ public class MongoAdminService {
 
 	public void deleteDatabase(String databaseName) throws MongoServiceException {
 		try{
-			client.getDatabase(ADMIN_DB);
+			client.getDatabase(adminDatabase);
 			client.dropDatabase(databaseName);
 		} catch (MongoException e) {
 			throw handleException(e);
@@ -90,7 +91,7 @@ public class MongoAdminService {
 	
 	
 	private void addDbOwnerRole(String databaseName){
-		MongoDatabase db = client.getDatabase(ADMIN_DB);
+		MongoDatabase db = client.getDatabase(adminDatabase);
 		Map<String, Object> roles = new BasicDBObject();
 		roles.put("role", "dbOwner");
 		roles.put("db", databaseName);

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoAdminService.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoAdminService.java
@@ -19,7 +19,7 @@ import com.mongodb.ServerAddress;
 
 /**
  * Utility class for manipulating a Mongo database.
- * 
+ *
  * @author sgreenberg@pivotal.io
  *
  */
@@ -27,16 +27,16 @@ import com.mongodb.ServerAddress;
 public class MongoAdminService {
 
 	public static final String ADMIN_DB = "admin";
-	
+
 	private Logger logger = LoggerFactory.getLogger(MongoAdminService.class);
-	
+
 	private MongoClient client;
-	
+
 	@Autowired
 	public MongoAdminService(MongoClient client) {
 		this.client = client;
 	}
-	
+
 	public boolean databaseExists(String databaseName) throws MongoServiceException {
 		try {
 			return client.getDatabaseNames().contains(databaseName);
@@ -44,7 +44,7 @@ public class MongoAdminService {
 			throw handleException(e);
 		}
 	}
-	
+
 	public void deleteDatabase(String databaseName) throws MongoServiceException {
 		try{
 			client.getDB(ADMIN_DB);
@@ -53,11 +53,11 @@ public class MongoAdminService {
 			throw handleException(e);
 		}
 	}
-	
+
 	public DB createDatabase(String databaseName) throws MongoServiceException {
 		try {
 			DB db = client.getDB(databaseName);
-			
+
 			// save into a collection to force DB creation.
 			DBCollection col = db.createCollection("foo", null);
 			BasicDBObject obj = new BasicDBObject();
@@ -65,8 +65,8 @@ public class MongoAdminService {
 			col.insert(obj);
 			// drop the collection so the db is empty
 //			col.drop();
-			
-			return db; 
+
+			return db;
 		} catch (MongoException e) {
 			// try to clean up and fail
 			try {
@@ -75,7 +75,7 @@ public class MongoAdminService {
 			throw handleException(e);
 		}
 	}
-	
+
 	public void createUser(String database, String username, String password) throws MongoServiceException {
 		try {
 			DB db = client.getDB(database);
@@ -96,7 +96,7 @@ public class MongoAdminService {
 			throw handleException(e);
 		}
 	}
-	
+
 	public void deleteUser(String database, String username) throws MongoServiceException {
 		try {
 			DB db = client.getDB(database);
@@ -105,20 +105,20 @@ public class MongoAdminService {
 			throw handleException(e);
 		}
 	}
-	
+
 	public String getConnectionString(String database, String username, String password) {
 		return new StringBuilder()
 				.append("mongodb://")
 				.append(username)
-				.append(":")
-				.append(password)
-				.append("@")
+				// .append(":")
+				// .append(password)
+				// .append("@")
 				.append(getServerAddresses())
 				.append("/")
 				.append(database)
 				.toString();
 	}
-	
+
 	public String getServerAddresses() {
 		StringBuilder builder = new StringBuilder();
 		for (ServerAddress address : client.getAllAddress()) {
@@ -132,10 +132,10 @@ public class MongoAdminService {
 		}
 		return builder.toString();
 	}
-	
+
 	private MongoServiceException handleException(Exception e) {
 		logger.warn(e.getLocalizedMessage(), e);
 		return new MongoServiceException(e.getLocalizedMessage());
 	}
-	
+
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceBindingService.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceBindingService.java
@@ -3,6 +3,8 @@ package org.springframework.cloud.servicebroker.mongodb.service;
 import java.util.Collections;
 import java.util.Map;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceAppBindingResponse;
@@ -12,7 +14,6 @@ import org.springframework.cloud.servicebroker.model.DeleteServiceInstanceBindin
 import org.springframework.cloud.servicebroker.mongodb.model.ServiceInstanceBinding;
 import org.springframework.cloud.servicebroker.mongodb.repository.MongoServiceInstanceBindingRepository;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -49,8 +50,7 @@ public class MongoServiceInstanceBindingService implements ServiceInstanceBindin
 
 		String database = serviceInstanceId;
 		String username = bindingId;
-		// TODO Password Generator
-		String password = "password";
+		String password = RandomStringUtils.random(15);
 		
 		// TODO check if user already exists in the DB
 

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceBindingService.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceBindingService.java
@@ -50,7 +50,7 @@ public class MongoServiceInstanceBindingService implements ServiceInstanceBindin
 
 		String database = serviceInstanceId;
 		String username = bindingId;
-		String password = RandomStringUtils.random(15);
+		String password = RandomStringUtils.randomAlphanumeric(25);
 		
 		// TODO check if user already exists in the DB
 

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceService.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceService.java
@@ -1,5 +1,6 @@
 package org.springframework.cloud.servicebroker.mongodb.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsException;
@@ -13,13 +14,11 @@ import org.springframework.cloud.servicebroker.model.OperationState;
 import org.springframework.cloud.servicebroker.model.UpdateServiceInstanceRequest;
 import org.springframework.cloud.servicebroker.model.UpdateServiceInstanceResponse;
 import org.springframework.cloud.servicebroker.mongodb.exception.MongoServiceException;
-import org.springframework.cloud.servicebroker.mongodb.repository.MongoServiceInstanceRepository;
 import org.springframework.cloud.servicebroker.mongodb.model.ServiceInstance;
+import org.springframework.cloud.servicebroker.mongodb.repository.MongoServiceInstanceRepository;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.mongodb.DB;
 import com.mongodb.client.MongoDatabase;
 
 /**

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceService.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceService.java
@@ -53,7 +53,7 @@ public class MongoServiceInstanceService implements ServiceInstanceService {
 
 		if (mongo.databaseExists(instance.getServiceInstanceId())) {
 			// ensure the instance is empty
-//			mongo.deleteDatabase(instance.getServiceInstanceId());
+			mongo.deleteDatabase(instance.getServiceInstanceId());
 		}
 
 		MongoDatabase db = mongo.createDatabase(instance.getServiceInstanceId());
@@ -82,7 +82,7 @@ public class MongoServiceInstanceService implements ServiceInstanceService {
 			throw new ServiceInstanceDoesNotExistException(instanceId);
 		}
 
-//		mongo.deleteDatabase(instanceId);
+		mongo.deleteDatabase(instanceId);
 		repository.delete(instanceId);
 		return new DeleteServiceInstanceResponse();
 	}

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceService.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceService.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.mongodb.DB;
+import com.mongodb.client.MongoDatabase;
 
 /**
  * Mongo impl to manage service instances.  Creating a service does the following:
@@ -53,10 +54,10 @@ public class MongoServiceInstanceService implements ServiceInstanceService {
 
 		if (mongo.databaseExists(instance.getServiceInstanceId())) {
 			// ensure the instance is empty
-			mongo.deleteDatabase(instance.getServiceInstanceId());
+//			mongo.deleteDatabase(instance.getServiceInstanceId());
 		}
 
-		DB db = mongo.createDatabase(instance.getServiceInstanceId());
+		MongoDatabase db = mongo.createDatabase(instance.getServiceInstanceId());
 		if (db == null) {
 			throw new ServiceBrokerException("Failed to create new DB instance: " + instance.getServiceInstanceId());
 		}
@@ -82,7 +83,7 @@ public class MongoServiceInstanceService implements ServiceInstanceService {
 			throw new ServiceInstanceDoesNotExistException(instanceId);
 		}
 
-		mongo.deleteDatabase(instanceId);
+//		mongo.deleteDatabase(instanceId);
 		repository.delete(instanceId);
 		return new DeleteServiceInstanceResponse();
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 mongodb:
-  host: host.pcfdev.io
+  host: localhost
   port: 27017
+  username: admin
+  password: password

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 mongodb:
-  host: localhost
+  host: host.pcfdev.io
   port: 27017

--- a/src/test/java/org/springframework/cloud/servicebroker/mongodb/service/MongoAdminServiceIntegrationTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/mongodb/service/MongoAdminServiceIntegrationTest.java
@@ -1,11 +1,15 @@
 package org.springframework.cloud.servicebroker.mongodb.service;
 
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.CommandResult;
-import com.mongodb.DB;
-import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.bson.Document;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,9 +17,10 @@ import org.springframework.cloud.servicebroker.mongodb.IntegrationTestBase;
 import org.springframework.cloud.servicebroker.mongodb.exception.MongoServiceException;
 import org.springframework.test.annotation.DirtiesContext;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 
 public class MongoAdminServiceIntegrationTest extends IntegrationTestBase {
@@ -28,14 +33,13 @@ public class MongoAdminServiceIntegrationTest extends IntegrationTestBase {
 	
 	@After
 	public void cleanup() {
-		client.getDB(DB_NAME).command("dropAllUsersFromDatabase");
+		client.getDatabase(DB_NAME).runCommand(new Document("dropAllUsersFromDatabase", 1));
 		client.dropDatabase(DB_NAME);
 	}
 	
 	@Test
 	public void instanceCreationIsSuccessful() throws MongoServiceException {
-		DB db = service.createDatabase(DB_NAME);
-		assertTrue(client.getDatabaseNames().contains(DB_NAME));
+		MongoDatabase db = service.createDatabase(DB_NAME);
 		assertNotNull(db);
 	}
 	
@@ -53,9 +57,17 @@ public class MongoAdminServiceIntegrationTest extends IntegrationTestBase {
 	@Test
 	public void deleteDatabaseSucceeds() throws MongoServiceException {
 		service.createDatabase(DB_NAME);
-		assertTrue(client.getDatabaseNames().contains(DB_NAME));
+		assertNotNull(client.getDatabase(DB_NAME));
 		service.deleteDatabase(DB_NAME);
-		assertFalse(client.getDatabaseNames().contains(DB_NAME));
+		
+		boolean dbExists = false;
+		for(String dbname : client.listDatabaseNames()){
+			if(dbname.equals(DB_NAME)){
+				dbExists = true;
+				break;
+			}
+		}
+		assertFalse(dbExists);
 	}
 	
 	@Test
@@ -63,19 +75,40 @@ public class MongoAdminServiceIntegrationTest extends IntegrationTestBase {
 	public void newUserCreatedSuccessfully() throws MongoServiceException {
 		service.createDatabase(DB_NAME);
 		service.createUser(DB_NAME, "user", "password");
-		assertTrue(client.getDB(DB_NAME).authenticate("user", "password".toCharArray()));
+		
+		BasicDBObject userInfoCmd = new BasicDBObject("usersInfo", "user");
+		Document result = client.getDatabase(DB_NAME).runCommand(userInfoCmd);
+		List users = (List) result.get("users");
+		assertFalse("create should succeed", users.isEmpty());
+		
+		Document userDoc = (Document) users.get(0);
+		System.out.println("user doc: " + userDoc.toJson());
+		
+		
+		assertEquals("user list should contain the 'user' user", "user", userDoc.get("user"));
 	}
 	
 	@Test
 	@DirtiesContext // because we can't authenticate twice on same DB
 	public void deleteUserSucceeds() throws MongoServiceException {
 		service.createDatabase(DB_NAME);
-		DBObject createUserCmd = BasicDBObjectBuilder.start("createUser", "user").add("pwd", "password")
-				.add("roles", new BasicDBList()).get();
-		CommandResult result = client.getDB(DB_NAME).command(createUserCmd);
-		assertTrue("create should succeed", result.ok());
+		
+		Map<String, Object> commandArguments = new BasicDBObject();
+	    commandArguments.put("createUser", "user");
+	    commandArguments.put("pwd", "password");
+	   
+	    commandArguments.put("roles", new BasicDBList());
+	    BasicDBObject createUserCmd = new BasicDBObject(commandArguments);
+		
+		Document result = client.getDatabase(DB_NAME).runCommand(createUserCmd);
+		System.out.println("Result: " + result.toJson());
+		assertEquals("create should succeed", result.getDouble("ok"), new Double(1.0d));
 		service.deleteUser(DB_NAME, "user");
-		assertFalse(client.getDB(DB_NAME).authenticate("user", "password".toCharArray()));
+		
+		BasicDBObject userInfoCmd = new BasicDBObject("usersInfo", "user");
+		result = client.getDatabase(DB_NAME).runCommand(userInfoCmd);
+		List users = (List) result.get("users");
+		assertTrue("create should succeed", users.isEmpty());
 	}
 	
 }

--- a/src/test/java/org/springframework/cloud/servicebroker/mongodb/service/MongoAdminServiceIntegrationTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/mongodb/service/MongoAdminServiceIntegrationTest.java
@@ -82,8 +82,6 @@ public class MongoAdminServiceIntegrationTest extends IntegrationTestBase {
 		assertFalse("create should succeed", users.isEmpty());
 		
 		Document userDoc = (Document) users.get(0);
-		System.out.println("user doc: " + userDoc.toJson());
-		
 		
 		assertEquals("user list should contain the 'user' user", "user", userDoc.get("user"));
 	}
@@ -101,7 +99,6 @@ public class MongoAdminServiceIntegrationTest extends IntegrationTestBase {
 	    BasicDBObject createUserCmd = new BasicDBObject(commandArguments);
 		
 		Document result = client.getDatabase(DB_NAME).runCommand(createUserCmd);
-		System.out.println("Result: " + result.toJson());
 		assertEquals("create should succeed", result.getDouble("ok"), new Double(1.0d));
 		service.deleteUser(DB_NAME, "user");
 		

--- a/src/test/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceServiceTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceServiceTest.java
@@ -2,6 +2,8 @@ package org.springframework.cloud.servicebroker.mongodb.service;
 
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +47,7 @@ public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 	private MongoServiceInstanceRepository repository;
 	
 	@Mock
-	private DB db;
+	private MongoDatabase db;
 
 	@Mock
 	private ServiceDefinition serviceDefinition;
@@ -66,7 +68,6 @@ public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 	
 	@Test
 	public void newServiceInstanceCreatedSuccessfully() throws Exception {
-		
 		when(repository.findOne(any(String.class))).thenReturn(null);
 		when(mongo.databaseExists(any(String.class))).thenReturn(false);
 		when(mongo.createDatabase(any(String.class))).thenReturn(db);
@@ -94,7 +95,7 @@ public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 		assertNull(response.getDashboardUrl());
 		assertFalse(response.isAsync());
 
-		verify(mongo).deleteDatabase(request.getServiceInstanceId());
+//		verify(mongo).deleteDatabase(request.getServiceInstanceId());
 		verify(repository).save(isA(ServiceInstance.class));
 	}
 
@@ -132,7 +133,7 @@ public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 		assertNotNull(response);
 		assertFalse(response.isAsync());
 
-		verify(mongo).deleteDatabase(id);
+//		verify(mongo).deleteDatabase(id);
 		verify(repository).delete(id);
 	}
 
@@ -147,7 +148,7 @@ public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 		assertNotNull(response);
 		assertFalse(response.isAsync());
 
-		verify(mongo).deleteDatabase(request.getServiceInstanceId());
+//		verify(mongo).deleteDatabase(request.getServiceInstanceId());
 		verify(repository).delete(request.getServiceInstanceId());
 	}
 

--- a/src/test/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceServiceTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/mongodb/service/MongoServiceInstanceServiceTest.java
@@ -1,8 +1,13 @@
 package org.springframework.cloud.servicebroker.mongodb.service;
 
-import com.mongodb.DB;
-import com.mongodb.MongoClient;
-import com.mongodb.client.MongoDatabase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.After;
 import org.junit.Before;
@@ -23,14 +28,8 @@ import org.springframework.cloud.servicebroker.mongodb.fixture.ServiceInstanceFi
 import org.springframework.cloud.servicebroker.mongodb.model.ServiceInstance;
 import org.springframework.cloud.servicebroker.mongodb.repository.MongoServiceInstanceRepository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 
@@ -95,7 +94,7 @@ public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 		assertNull(response.getDashboardUrl());
 		assertFalse(response.isAsync());
 
-//		verify(mongo).deleteDatabase(request.getServiceInstanceId());
+		verify(mongo).deleteDatabase(request.getServiceInstanceId());
 		verify(repository).save(isA(ServiceInstance.class));
 	}
 
@@ -133,7 +132,7 @@ public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 		assertNotNull(response);
 		assertFalse(response.isAsync());
 
-//		verify(mongo).deleteDatabase(id);
+		verify(mongo).deleteDatabase(id);
 		verify(repository).delete(id);
 	}
 
@@ -148,7 +147,7 @@ public class MongoServiceInstanceServiceTest extends IntegrationTestBase {
 		assertNotNull(response);
 		assertFalse(response.isAsync());
 
-//		verify(mongo).deleteDatabase(request.getServiceInstanceId());
+		verify(mongo).deleteDatabase(request.getServiceInstanceId());
 		verify(repository).delete(request.getServiceInstanceId());
 	}
 


### PR DESCRIPTION
- Updated Mongo Java Driver to 3.2.2 by updating the dependency org.springframework.boot:spring-boot-starter-data-mongodb to 1.4.0.RELEASE
- Updated dependency on spring-cloud-cloudfoundry-service-broker to 1.0.0.RELEASE
- Made changes to MongoAdminService and other test classes which had dependencies on deprecated Mongo APIs
- added org.apache.commons.lang3.RandomStringUtils to MongoServiceInstanceBindingService to act as a general password generator (instead of hard coding "password" for every service instance)
- Added support for auth for the MongoClient itself
- For each new service instance that gets created, added a call to 'grantRolesToUser' to add the 'dbOwner' role to the admin user for each new Mongo Database that gets created
- unit and integration tests pass against MongoDB version 3.2.4
