### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Build it:
 
     ./gradlew build
 
-After building, you can push the broker app to Cloud Foundry or deploy it some other way and then [register it to Cloud Foundry](http://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker).
+After building, you can push the broker app to Cloud Foundry or deploy it some other way and then [register it to Cloud Foundry](https://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker).
 
 
 ## Enable Auth in your MongoDB instance
@@ -48,7 +48,7 @@ Push the service broker as an app to Cloud Foundry:
 `cf push`
 
 Register the service broker using the default username and the password obtained from the previous step:
-`cf csb mongodb admin admin http://mongodb-service-broker.local.pcfdev.io`
+`cf csb mongodb admin admin https://mongodb-service-broker.local.pcfdev.io`
 
 Enable access to the service broker:
 `cf enable-service-access mongodb`

--- a/charts/service-broker-mongodb/templates/mongodb-service-broker.yaml
+++ b/charts/service-broker-mongodb/templates/mongodb-service-broker.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceBroker
 metadata:
   name: {{ template "fullname" . }}
 spec:
-  url: http://service-broker-mongodb-service-broker-mongodb.default.svc.cluster.local
+  url: https://service-broker-mongodb-service-broker-mongodb.default.svc.cluster.local
   authInfo:
     basic:
       secretRef:

--- a/src/main/java/org/springframework/cloud/servicebroker/mongodb/config/CatalogConfig.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/mongodb/config/CatalogConfig.java
@@ -40,7 +40,7 @@ public class CatalogConfig {
 	private Map<String, Object> getServiceDefinitionMetadata() {
 		Map<String, Object> sdMetadata = new HashMap<>();
 		sdMetadata.put("displayName", "MongoDB");
-		sdMetadata.put("imageUrl", "http://info.mongodb.com/rs/mongodb/images/MongoDB_Logo_Full.png");
+		sdMetadata.put("imageUrl", "https://info.mongodb.com/rs/mongodb/images/MongoDB_Logo_Full.png");
 		sdMetadata.put("longDescription", "MongoDB Service");
 		sdMetadata.put("providerDisplayName", "Pivotal");
 		sdMetadata.put("documentationUrl", "https://github.com/spring-cloud-samples/cloudfoundry-mongodb-service-broker");

--- a/src/test/java/org/springframework/cloud/servicebroker/mongodb/fixture/ServiceInstanceFixture.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/mongodb/fixture/ServiceInstanceFixture.java
@@ -5,6 +5,6 @@ import org.springframework.cloud.servicebroker.mongodb.model.ServiceInstance;
 public class ServiceInstanceFixture {
 	public static ServiceInstance getServiceInstance() {
 		return new ServiceInstance("service-instance-id", "service-definition-id", "plan-id",
-				"org-guid", "space-guid", "http://dashboard.example.com");
+				"org-guid", "space-guid", "https://dashboard.example.com");
 	}
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://mongodb-service-broker.local.pcfdev.io (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://mongodb-service-broker.local.pcfdev.io ([https](https://mongodb-service-broker.local.pcfdev.io) result ConnectTimeoutException).
* [ ] http://dashboard.example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://dashboard.example.com ([https](https://dashboard.example.com) result UnknownHostException).
* [ ] http://service-broker-mongodb-service-broker-mongodb.default.svc.cluster.local (UnknownHostException) with 1 occurrences migrated to:  
  https://service-broker-mongodb-service-broker-mongodb.default.svc.cluster.local ([https](https://service-broker-mongodb-service-broker-mongodb.default.svc.cluster.local) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.cloudfoundry.org/services/managing-service-brokers.html with 1 occurrences migrated to:  
  https://docs.cloudfoundry.org/services/managing-service-brokers.html ([https](https://docs.cloudfoundry.org/services/managing-service-brokers.html) result 200).
* [ ] http://info.mongodb.com/rs/mongodb/images/MongoDB_Logo_Full.png with 1 occurrences migrated to:  
  https://info.mongodb.com/rs/mongodb/images/MongoDB_Logo_Full.png ([https](https://info.mongodb.com/rs/mongodb/images/MongoDB_Logo_Full.png) result 302).